### PR TITLE
Using floating go 1.21 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.7 AS builder
+FROM golang:1.21 AS builder
 WORKDIR /src/
 COPY . /src/
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/aactl
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/containeranalysis v0.10.1


### PR DESCRIPTION
This will help reduce reported vulnerabilities, by always building with the latest patch version.